### PR TITLE
feat: Implement SDK-side capabilities so web experiences can be evalu…

### DIFF
--- a/packages/data/src/data-manager.ts
+++ b/packages/data/src/data-manager.ts
@@ -83,6 +83,7 @@ export class DataManager implements DataManagerInterface {
   private _asyncStorage: boolean;
   private _environment: string;
   private _mapper: (...args: any) => any;
+  private _ruleDataProvider?: Record<string, any>;
   /**
    * @param {Config} config
    * @param {Object} dependencies
@@ -124,6 +125,7 @@ export class DataManager implements DataManagerInterface {
     this._data = objectDeepValue(config, 'data');
     this._accountId = this._data?.account_id;
     this._projectId = this._data?.project?.id;
+    this._ruleDataProvider = config?.ruleDataProvider;
     this.dataStoreManager = config?.dataStore;
     this._loggerManager?.trace?.(
       'DataManager()',
@@ -143,6 +145,15 @@ export class DataManager implements DataManagerInterface {
         ERROR_MESSAGES.CONFIG_DATA_NOT_VALID
       );
     }
+  }
+
+  private _getRuleData(
+    properties?: Record<string, any>
+  ): Record<string, any> {
+    if (this._ruleManager.isUsingCustomInterface(this._ruleDataProvider)) {
+      return this._ruleDataProvider;
+    }
+    return properties;
   }
 
   /**
@@ -291,7 +302,8 @@ export class DataManager implements DataManagerInterface {
     // Check location rules against locationProperties
     let locationMatched: boolean | RuleError =
       ignoreLocationProperties === true;
-    if (!locationMatched && locationProperties) {
+    const ruleData = this._getRuleData(locationProperties);
+    if (!locationMatched && (locationProperties || this._ruleDataProvider)) {
       if (Array.isArray(experience?.locations) && experience.locations.length) {
         let matchedLocations = [];
         // Get attached locations
@@ -303,7 +315,7 @@ export class DataManager implements DataManagerInterface {
           // Validate locationProperties against locations rules
           // and trigger activated/deactivated events
           matchedLocations = this.selectLocations(visitorId, locations, {
-            locationProperties,
+            locationProperties: ruleData,
             identityField
           });
           // Return rule errors if present
@@ -317,7 +329,7 @@ export class DataManager implements DataManagerInterface {
       } else if (experience?.site_area) {
         // Validate locationProperties against site area rules
         locationMatched = this._ruleManager.isRuleMatched(
-          locationProperties,
+          ruleData,
           experience.site_area,
           'SiteArea'
         );
@@ -355,7 +367,8 @@ export class DataManager implements DataManagerInterface {
       audiencesToCheck: Array<ConfigAudience> = [],
       audiencesMatched = false,
       segmentsMatched = false;
-    if (visitorProperties) {
+    const visitorRuleData = this._getRuleData(visitorProperties);
+    if (visitorRuleData) {
       if (Array.isArray(experience?.audiences) && experience.audiences.length) {
         // Get attached transient and/or permnent audiences
         audiences = this.getItemsByIds(
@@ -372,7 +385,7 @@ export class DataManager implements DataManagerInterface {
           // Validate visitorProperties against audiences rules
           matchedAudiences = this.filterMatchedRecordsWithRule(
             audiencesToCheck,
-            visitorProperties,
+            visitorRuleData,
             'audience',
             identityField
           );
@@ -704,17 +717,18 @@ export class DataManager implements DataManagerInterface {
     }
 
     // Build the response as bucketed variation object
-    if (variation) {
-      bucketedVariation = {
-        ...{
-          experienceId: experience?.id,
-          experienceName: experience?.name,
-          experienceKey: experience?.key
-        },
-        bucketingAllocation,
-        ...variation
-      };
-    }
+      if (variation) {
+        bucketedVariation = {
+          ...{
+            experienceId: experience?.id,
+            experienceName: experience?.name,
+            experienceKey: experience?.key,
+            experienceType: experience?.type
+          },
+          bucketingAllocation,
+          ...variation
+        };
+      }
 
     return bucketedVariation as BucketedVariation;
   }
@@ -850,13 +864,14 @@ export class DataManager implements DataManagerInterface {
     );
     // Get locations from DataStore
     const {locations = []} = this.getData(visitorId) || {};
+    const ruleData = this._getRuleData(locationProperties);
     const matchedRecords = [];
     let match;
     if (arrayNotEmpty(items)) {
       for (let i = 0, length = items.length; i < length; i++) {
         if (!items?.[i]?.rules) continue;
         match = this._ruleManager.isRuleMatched(
-          locationProperties,
+          ruleData,
           items[i].rules,
           `ConfigLocation #${items[i][identityField]}`
         );
@@ -1107,12 +1122,13 @@ export class DataManager implements DataManagerInterface {
       })
     );
     const matchedRecords = [];
+    const ruleData = this._getRuleData(visitorProperties);
     let match;
     if (arrayNotEmpty(items)) {
       for (let i = 0, length = items.length; i < length; i++) {
         if (!items?.[i]?.rules) continue;
         match = this._ruleManager.isRuleMatched(
-          visitorProperties,
+          ruleData,
           items[i].rules,
           `${camelCase(entityType)} #${items[i][field]}`
         );

--- a/packages/data/src/data-manager.ts
+++ b/packages/data/src/data-manager.ts
@@ -722,8 +722,7 @@ export class DataManager implements DataManagerInterface {
           ...{
             experienceId: experience?.id,
             experienceName: experience?.name,
-            experienceKey: experience?.key,
-            experienceType: experience?.type
+            experienceKey: experience?.key
           },
           bucketingAllocation,
           ...variation

--- a/packages/experience/src/experience-manager.ts
+++ b/packages/experience/src/experience-manager.ts
@@ -156,7 +156,12 @@ export class ExperienceManager implements ExperienceManagerInterface {
     visitorId: string,
     attributes: BucketingAttributes
   ): Array<BucketedVariation | RuleError | BucketingError> {
-    return this.getList()
+    const experienceList = attributes?.experienceTypes?.length
+      ? this.getList().filter(({type}) =>
+          attributes.experienceTypes.includes(type)
+        )
+      : this.getList();
+    return experienceList
       .map((experience) => {
         return this.selectVariation(visitorId, experience?.key, attributes);
       })

--- a/packages/js-sdk/src/context.ts
+++ b/packages/js-sdk/src/context.ts
@@ -52,6 +52,7 @@ export class Context implements ContextInterface {
   private _apiManager: ApiManagerInterface;
   private _loggerManager: LogManagerInterface;
   private _config: Config;
+  private _mapper: (...args: any) => any;
   private _visitorId: string;
   private _visitorProperties: Record<string, any>;
   private _environment: string;
@@ -102,6 +103,7 @@ export class Context implements ContextInterface {
     this._segmentsManager = segmentsManager;
     this._apiManager = apiManager;
     this._loggerManager = loggerManager;
+    this._mapper = config?.mapper || ((value: any) => value);
 
     if (objectNotEmpty(visitorProperties)) {
       const {properties} =
@@ -766,6 +768,5 @@ export class Context implements ContextInterface {
     (document.body || document.head || document.documentElement).appendChild(
       scriptElement
     );
-    scriptElement.remove();
   }
 }

--- a/packages/js-sdk/src/context.ts
+++ b/packages/js-sdk/src/context.ts
@@ -29,6 +29,7 @@ import {
   BucketingError,
   ERROR_MESSAGES,
   EntityType,
+  VariationChangeType,
   RuleError,
   SystemEvents
 } from '@convertcom/js-sdk-enums';
@@ -54,6 +55,8 @@ export class Context implements ContextInterface {
   private _visitorId: string;
   private _visitorProperties: Record<string, any>;
   private _environment: string;
+  private _appliedVariationSignatures = new Set<string>();
+  private _appliedVariationAssets = new Set<string>();
 
   /**
    * @param {Config} config
@@ -163,6 +166,123 @@ export class Context implements ContextInterface {
       );
     }
     return bucketedVariation as BucketedVariation;
+  }
+
+  /**
+   * Render web variation changes in DOM
+   * @param {BucketedVariation} bucketedVariation
+   * @param {{ experience?: ConfigExperience }=} options
+   */
+  runVariation(
+    bucketedVariation: BucketedVariation,
+    options?: {
+      experience?: ConfigExperience;
+    }
+  ): void {
+    const variationSignature = this._getVariationSignature(bucketedVariation, options);
+    if (this._appliedVariationSignatures.has(variationSignature)) {
+      this._loggerManager?.debug?.(
+        'Context.runVariation()',
+        `runVariation() variation already applied: ${variationSignature}`
+      );
+      return;
+    }
+
+    if (!this._canRunInBrowser()) {
+      this._loggerManager?.warn?.(
+        'Context.runVariation()',
+        'runVariation() skipped: DOM not available'
+      );
+      return;
+    }
+
+    const experience = options?.experience || (this.getConfigEntity(
+      bucketedVariation.experienceKey,
+      EntityType.EXPERIENCE
+    ) as ConfigExperience);
+    if (!experience) {
+      this._loggerManager?.error?.(
+        'Context.runVariation()',
+        `runVariation() skipped: experience not found for ${bucketedVariation.experienceKey}`
+      );
+      return;
+    }
+
+    // Apply experience-level assets
+    if (experience.global_css) {
+      this._safeExecute(
+        () =>
+          this._injectStyle(
+            experience.global_css,
+            variationSignature,
+            `${experience.key || bucketedVariation.experienceKey}-global-css`
+          ),
+        'global css'
+      );
+    }
+    if (experience.global_js) {
+      this._safeExecute(
+        () =>
+          this._injectScript(
+            experience.global_js,
+            variationSignature,
+            `${experience.key || bucketedVariation.experienceKey}-global-js`
+          ),
+        'global js'
+      );
+    }
+
+    // Apply variation-level changes
+    const changes = bucketedVariation.changes || [];
+    changes.forEach((change, index) => {
+      if (!change?.type) return;
+      if (change.type === VariationChangeType.DEFAULT_REDIRECT) {
+        this._loggerManager?.warn?.(
+          'Context.runVariation()',
+          'runVariation() skipped change: defaultRedirect',
+          this._mapper({signature: variationSignature, changeIndex: index})
+        );
+        return;
+      }
+      if (change.type === VariationChangeType.FULLSTACK_FEATURE) {
+        this._loggerManager?.warn?.(
+          'Context.runVariation()',
+          'runVariation() skipped change: fullStackFeature',
+          this._mapper({signature: variationSignature, changeIndex: index})
+        );
+        return;
+      }
+
+      const data: Record<string, any> = change.data || {};
+      const changeId = `${variationSignature}:${change.id || index}`;
+      if (data.css) {
+        this._safeExecute(
+          () =>
+            this._injectStyle(data.css, variationSignature, `${changeId}-css`),
+          `variation css (${change.type})`
+        );
+      }
+      if (data.js) {
+        this._safeExecute(
+          () =>
+            this._injectScript(data.js, variationSignature, `${changeId}-js`),
+          `variation js (${change.type})`
+        );
+      }
+      if (data.custom_js) {
+        this._safeExecute(
+          () =>
+            this._injectScript(
+              data.custom_js,
+              variationSignature,
+              `${changeId}-custom-js`
+            ),
+          `custom js (${change.type})`
+        );
+      }
+    });
+
+    this._appliedVariationSignatures.add(variationSignature);
   }
 
   /**
@@ -576,5 +696,76 @@ export class Context implements ContextInterface {
       ? objectDeepMerge(this._visitorProperties || {}, attributes)
       : this._visitorProperties;
     return objectDeepMerge(segments || {}, visitorProperties || {});
+  }
+
+  private _getVariationSignature(
+    bucketedVariation: BucketedVariation,
+    options?: {
+      experience?: ConfigExperience;
+    }
+  ): string {
+    const variationId =
+      (bucketedVariation as Record<string, any>)?.id ||
+      bucketedVariation?.key ||
+      bucketedVariation?.experienceId ||
+      '';
+    const experienceKey =
+      options?.experience?.key ||
+      bucketedVariation.experienceKey ||
+      String(bucketedVariation.experienceId || '');
+    return `${experienceKey}:${variationId}`;
+  }
+
+  private _safeExecute(callback: () => void, action: string): void {
+    try {
+      callback();
+    } catch (error) {
+      this._loggerManager?.error?.(
+        'Context.runVariation()',
+        `runVariation() ${action} execution failed`,
+        error?.message || error
+      );
+    }
+  }
+
+  private _canRunInBrowser(): boolean {
+    return (
+      typeof window !== 'undefined' && typeof document !== 'undefined' && !!document
+    );
+  }
+
+  private _shouldApplyAsset(assetSignature: string): boolean {
+    if (this._appliedVariationAssets.has(assetSignature)) return false;
+    this._appliedVariationAssets.add(assetSignature);
+    return true;
+  }
+
+  private _injectStyle(
+    css: string,
+    variationSignature: string,
+    name: string
+  ): void {
+    const signature = `${variationSignature}:${name}-style`;
+    if (!css || !this._shouldApplyAsset(signature)) return;
+    const styleElement = document.createElement('style');
+    styleElement.type = 'text/css';
+    styleElement.textContent = css;
+    (document.head || document.documentElement).appendChild(styleElement);
+  }
+
+  private _injectScript(
+    code: string,
+    variationSignature: string,
+    name: string
+  ): void {
+    const signature = `${variationSignature}:${name}-script`;
+    if (!code || !this._shouldApplyAsset(signature)) return;
+    const scriptElement = document.createElement('script');
+    scriptElement.type = 'text/javascript';
+    scriptElement.appendChild(document.createTextNode(code));
+    (document.body || document.head || document.documentElement).appendChild(
+      scriptElement
+    );
+    scriptElement.remove();
   }
 }

--- a/packages/js-sdk/src/interfaces/context.ts
+++ b/packages/js-sdk/src/interfaces/context.ts
@@ -12,6 +12,7 @@ import {
   ConversionAttributes,
   Entity,
   SegmentsAttributes,
+  ConfigExperience,
   StoreData,
   VisitorSegments
 } from '@convertcom/js-sdk-types';
@@ -22,6 +23,13 @@ export interface ContextInterface {
     experienceKey: string,
     attributes?: BucketingAttributes
   ): BucketedVariation | RuleError | BucketingError;
+
+  runVariation(
+    bucketedVariation: BucketedVariation,
+    options?: {
+      experience?: ConfigExperience;
+    }
+  ): void;
 
   runExperiences(
     attributes?: BucketingAttributes

--- a/packages/js-sdk/tests/context.tests.ts
+++ b/packages/js-sdk/tests/context.tests.ts
@@ -504,4 +504,141 @@ describe('Context tests', function () {
       expect(output).to.be.undefined;
     });
   });
+
+  describe('runVariation script injection lifecycle', function () {
+    let testContext;
+    const createDomContainer = () => {
+      const children: any[] = [];
+      return {
+        children,
+        appendChild(node: any) {
+          this.children.push(node);
+          node.parentNode = this;
+          return node;
+        }
+      };
+    };
+    const setupBrowserDom = () => {
+      const head = createDomContainer();
+      const body = createDomContainer();
+      const documentElement = createDomContainer();
+
+      return {
+        head,
+        body,
+        documentElement,
+        createElement: (tagName: string) => {
+          const node: any = {
+            tagName,
+            type: '',
+            childNodes: [],
+            appendChild(child: any) {
+              if (child?.textContent !== undefined) {
+                this.text = child.textContent;
+              }
+              this.childNodes.push(child);
+              return child;
+            },
+            remove() {
+              this.removed = true;
+            },
+            textContent: ''
+          };
+          return node;
+        },
+        createTextNode(text: string) {
+          return {
+            textContent: text
+          };
+        }
+      };
+    };
+
+    const getAllScripts = (dom: any) => [
+      ...dom.head.children,
+      ...dom.body.children,
+      ...dom.documentElement.children
+    ].filter((node) => node?.tagName === 'script');
+
+    beforeEach(function () {
+      const dataManager = new dm(configuration, {
+        bucketingManager,
+        ruleManager,
+        eventManager,
+        apiManager
+      });
+      const experienceManager = new exm(configuration, {dataManager});
+      const featureManager = new fm(configuration, {dataManager});
+      const segmentsManager = new sm(configuration, {dataManager, ruleManager});
+      testContext = new c(
+        configuration,
+        visitorId,
+        {
+          eventManager,
+          experienceManager,
+          featureManager,
+          segmentsManager,
+          dataManager,
+          apiManager
+        },
+        {browser: 'chrome', country: 'US'}
+      );
+    });
+
+    afterEach(function () {
+      const globalAny = globalThis as any;
+      delete globalAny.window;
+      delete globalAny.document;
+    });
+
+    it('keeps script elements in DOM to preserve runtime-defined globals', function () {
+      const globalAny = globalThis as any;
+      const dom = setupBrowserDom();
+      globalAny.window = {};
+      globalAny.document = dom;
+
+      const variation: any = {
+        id: '100299461',
+        key: '100299461-variation-1',
+        experienceKey: 'test-experience-script',
+        name: 'Variation with scripts',
+        status: 'running',
+        is_baseline: false,
+        traffic_allocation: 50,
+        changes: [
+          {
+            id: 'change-1',
+            type: 'ab_variation',
+            data: {
+              js: 'window.__runVariationJs = true;',
+              custom_js: 'window.__runVariationCustomJs = true;'
+            }
+          }
+        ]
+      };
+
+      const experience: any = {
+        id: '100218246',
+        key: 'test-experience-script',
+        global_js: 'window.__runVariationGlobalJs = true;'
+      };
+
+      testContext.runVariation(variation, {experience});
+      const scriptsAfterFirstRun = getAllScripts(dom);
+      expect(scriptsAfterFirstRun.length).to.equal(3);
+      expect(scriptsAfterFirstRun.every((script) => !script.removed)).to.equal(
+        true
+      );
+      expect(
+        scriptsAfterFirstRun.map((script: any) => script.text)
+      ).to.deep.equal([
+        'window.__runVariationGlobalJs = true;',
+        'window.__runVariationJs = true;',
+        'window.__runVariationCustomJs = true;'
+      ]);
+
+      testContext.runVariation(variation, {experience});
+      expect(getAllScripts(dom).length).to.equal(3);
+    });
+  });
 });

--- a/packages/types/src/BucketedVariation.ts
+++ b/packages/types/src/BucketedVariation.ts
@@ -11,5 +11,6 @@ export type BucketedVariation = ExperienceVariationConfig & {
   experienceId?: string;
   experienceKey?: string;
   experienceName?: string;
+  experienceType?: string;
   bucketingAllocation?: number;
 };

--- a/packages/types/src/BucketingAttributes.ts
+++ b/packages/types/src/BucketingAttributes.ts
@@ -11,6 +11,7 @@ export type BucketingAttributes = {
   visitorProperties?: Record<any, any>;
   typeCasting?: boolean;
   experienceKeys?: Array<string>;
+  experienceTypes?: Array<string>;
   updateVisitorProperties?: boolean;
   forceVariationId?: string;
   enableTracking?: boolean;

--- a/packages/types/src/Config.ts
+++ b/packages/types/src/Config.ts
@@ -34,6 +34,7 @@ type ConfigBase = {
     negation?: string;
     keys_case_sensitive?: boolean;
   };
+  ruleDataProvider?: Record<string, any>;
   logger?: {
     logLevel?: LogLevel;
     file?: {


### PR DESCRIPTION
  # PR: [Epic A] Implement web hybrid SDK capabilities (A-1 to A-5)

  ## Summary

 SDK API support for web experiences by extending the JS SDK data flow and context runtime so web
  experiences can be safely evaluated and rendered from the SDK, while preserving existing behavior for monolith/fullstack users.
  Task 1 scope note: already completed on a separate branch, as documented in web-sdk-hybrid-user-stories.md.

  ## What’s Changed

  - Add experienceType to bucketing payload so web/fullstack consumers can distinguish experience source.
  - Add experienceTypes filtering to runExperiences() so execution can be limited to web or fullstack variants.
  - Add ruleDataProvider support in SDK config and wire it into rule evaluation paths.
  - Add deterministic runVariation() API in Context for runtime application of web changes (CSS/JS/custom JS order and safety
    behavior).
  - Expand public typings to include new config options and context API surface.

  ## Epic/User Story Coverage

  - A-1 BucketedVariation.experienceType + bucketing propagation (covered)
  - A-2 experienceTypes filtering in runExperiences() flow (covered)
  - A-3 ruleDataProvider config + RuleData-backed evaluation (covered)
  - A-4 Context.runVariation(...) implementation (covered)
  - A-5 Types updated for new API/contracts (covered)

  ## Files Changed

  - packages/types/src/BucketedVariation.ts
  - packages/data/src/data-manager.ts
  - packages/experience/src/experience-manager.ts
  - packages/js-sdk/src/context.ts
  - packages/js-sdk/src/interfaces/context.ts
  - packages/types/src/BucketingAttributes.ts
  - packages/types/src/Config.ts