### PR TITLE
feat: adding cookie (exist , not exist) conditions

### DIFF
--- a/packages/rules/src/rule-manager.ts
+++ b/packages/rules/src/rule-manager.ts
@@ -15,6 +15,7 @@ import {RuleManagerInterface} from './interfaces/rule-manager';
 
 import {
   Config,
+  CookieMatchingOptions,
   RuleElement,
   RuleAnd,
   RuleOrWhen,
@@ -165,15 +166,19 @@ export class RuleManager implements RuleManagerInterface {
         rule: rule
       })
     );
-    return (
+    const hasMatching =
       Object.prototype.hasOwnProperty.call(rule, 'matching') &&
       typeof rule.matching === 'object' &&
       Object.prototype.hasOwnProperty.call(rule.matching, 'match_type') &&
       typeof rule.matching.match_type === 'string' &&
       Object.prototype.hasOwnProperty.call(rule.matching, 'negated') &&
-      typeof rule.matching.negated === 'boolean' &&
-      Object.prototype.hasOwnProperty.call(rule, 'value')
-    );
+      typeof rule.matching.negated === 'boolean';
+    if (!hasMatching) return false;
+    const matchType = rule.matching.match_type as string;
+    if (matchType === CookieMatchingOptions.EXISTS || matchType === CookieMatchingOptions.DOES_NOT_EXIST) {
+      return true;
+    }
+    return Object.prototype.hasOwnProperty.call(rule, 'value');
   }
 
   /**
@@ -263,7 +268,7 @@ export class RuleManager implements RuleManagerInterface {
     if (this.isValidRule(rule)) {
       try {
         const negation = rule.matching.negated || false;
-        const matching = rule.matching.match_type;
+        const matching = rule.matching.match_type as string;
         if (this.getComparisonProcessorMethods().indexOf(matching) !== -1) {
           if (data && typeof data === 'object') {
             // Validate data key-value set.
@@ -314,7 +319,19 @@ export class RuleManager implements RuleManagerInterface {
                   );
                 }
               }
-            } else {
+            }
+            // Key not found or data empty — for existence operators, evaluate with undefined
+            if (
+              matching === CookieMatchingOptions.EXISTS ||
+              matching === CookieMatchingOptions.DOES_NOT_EXIST
+            ) {
+              return this._comparisonProcessor[matching](
+                undefined,
+                rule.value,
+                negation
+              );
+            }
+            if (!objectNotEmpty(data) && !this.isUsingCustomInterface(data)) {
               this._loggerManager?.trace?.('RuleManager._processRuleItem()', {
                 warn: ERROR_MESSAGES.RULE_DATA_NOT_VALID,
                 data

--- a/packages/rules/tests/rule-manager.tests.ts
+++ b/packages/rules/tests/rule-manager.tests.ts
@@ -534,6 +534,124 @@ describe('RuleManager tests', function () {
         expect(ruleManager.isRuleMatched(data32, testRuleSet3)).to.equal(true);
       }
     );
+    it('isValidRule should return true for exists rule without value', function () {
+      expect(
+        ruleManager.isValidRule({
+          key: 'myCookie',
+          matching: {
+            match_type: 'exists',
+            negated: false
+          }
+        })
+      ).to.equal(true);
+    });
+    it('isValidRule should return true for doesNotExist rule without value', function () {
+      expect(
+        ruleManager.isValidRule({
+          key: 'myCookie',
+          matching: {
+            match_type: 'doesNotExist',
+            negated: false
+          }
+        })
+      ).to.equal(true);
+    });
+    it('isRuleMatched should return true for exists when key is present', function () {
+      const data = {myCookie: 'someValue'};
+      const ruleSet = {
+        OR: [
+          {
+            AND: [
+              {
+                OR_WHEN: [
+                  {
+                    key: 'myCookie',
+                    matching: {
+                      match_type: 'exists',
+                      negated: false
+                    },
+                    value: ''
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      };
+      expect(ruleManager.isRuleMatched(data, ruleSet)).to.equal(true);
+    });
+    it('isRuleMatched should return false for exists when key is not present', function () {
+      const data = {otherCookie: 'someValue'};
+      const ruleSet = {
+        OR: [
+          {
+            AND: [
+              {
+                OR_WHEN: [
+                  {
+                    key: 'myCookie',
+                    matching: {
+                      match_type: 'exists',
+                      negated: false
+                    },
+                    value: ''
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      };
+      expect(ruleManager.isRuleMatched(data, ruleSet)).to.equal(false);
+    });
+    it('isRuleMatched should return true for doesNotExist when key is not present', function () {
+      const data = {otherCookie: 'someValue'};
+      const ruleSet = {
+        OR: [
+          {
+            AND: [
+              {
+                OR_WHEN: [
+                  {
+                    key: 'myCookie',
+                    matching: {
+                      match_type: 'doesNotExist',
+                      negated: false
+                    },
+                    value: ''
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      };
+      expect(ruleManager.isRuleMatched(data, ruleSet)).to.equal(true);
+    });
+    it('isRuleMatched should return false for doesNotExist when key is present', function () {
+      const data = {myCookie: 'someValue'};
+      const ruleSet = {
+        OR: [
+          {
+            AND: [
+              {
+                OR_WHEN: [
+                  {
+                    key: 'myCookie',
+                    matching: {
+                      match_type: 'doesNotExist',
+                      negated: false
+                    },
+                    value: ''
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      };
+      expect(ruleManager.isRuleMatched(data, ruleSet)).to.equal(false);
+    });
     it('Should allow to change comparison processor on fly', function () {
       const customComparisonProcessor = {
         isTypeOf: function (

--- a/packages/utils/src/comparisons.ts
+++ b/packages/utils/src/comparisons.ts
@@ -151,6 +151,26 @@ export class Comparisons {
     return this._returnNegationCheck(regExp.test(value), negation);
   }
 
+  static exists(
+    value: string | number | undefined | null,
+    testAgainst?: any,
+    negation?: boolean
+  ): boolean {
+    const valueExists = value !== undefined && value !== null && value !== '';
+    return this._returnNegationCheck(valueExists, negation);
+  }
+
+  static not_exists(
+    value: string | number | undefined | null,
+    testAgainst?: any,
+    negation?: boolean
+  ): boolean {
+    const valueNotExists = value === undefined || value === null || value === '';
+    return this._returnNegationCheck(valueNotExists, negation);
+  }
+
+  static doesNotExist = this.not_exists;
+
   private static _returnNegationCheck(
     value: boolean,
     negation = false

--- a/packages/utils/tests/comparisons.tests.ts
+++ b/packages/utils/tests/comparisons.tests.ts
@@ -319,5 +319,28 @@ describe('Comparison Processor utils tests', function () {
     );
     expect(result).to.equal(false);
   });
+  // Existence operator tests — 'exists' expects true when value is present,
+  // 'not_exists' and 'doesNotExist' expect the inverse.
+  const existenceCases: {input: any; label: string; negation?: boolean}[] = [
+    {input: 'cookieValue', label: 'a non-empty string value'},
+    {input: 123, label: 'a numeric value'},
+    {input: undefined, label: 'undefined'},
+    {input: null, label: 'null'},
+    {input: '', label: 'empty string'},
+    {input: 'cookieValue', label: 'non-empty string with negation', negation: true},
+    {input: undefined, label: 'undefined with negation', negation: true}
+  ];
+  for (const method of ['exists', 'not_exists', 'doesNotExist'] as const) {
+    for (const {input, label, negation} of existenceCases) {
+      const valuePresent = input !== undefined && input !== null && input !== '';
+      const isExistsMethod = method === 'exists';
+      const baseResult = isExistsMethod ? valuePresent : !valuePresent;
+      const expected = negation ? !baseResult : baseResult;
+      it(`${method} should return ${expected} for ${label}`, function () {
+        const result = Comparisons[method](input, null, negation);
+        expect(result).to.equal(expected);
+      });
+    }
+  }
   /* eslint-enable */
 });


### PR DESCRIPTION
Changes:
1- Add exists, not_exists, and doesNotExist comparison methods to evaluate cookie presence/absence without value matching
2- Update RuleManager.isValidRule() to allow existence operators without a value field
3- Update RuleManager._processRuleItem() to correctly evaluate existence operators when the key is missing or data is empty
4- Add unit tests for all new comparison methods and rule evaluation scenarios
