### PR TITLE
fix(ci): pin yarn to 4.10.3 and regenerate lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "demo:cloudflare:start": "cd demo/cloudflare-workers && yarn dev"
   },
   "private": true,
+  "packageManager": "yarn@4.10.3+sha512.c38cafb5c7bb273f3926d04e55e1d8c9dfa7d9c3ea1f36a4868fa028b9e5f72298f0b7f401ad5eb921749eb012eb1c3bb74bf7503df3ee43fd600d14a018266f",
   "workspaces": [
     "packages/*",
     "demo/*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 9
+  version: 8
   cacheKey: 10c0
 
 "@alloc/quick-lru@npm:^5.2.0":


### PR DESCRIPTION
## Summary

Staging deploys for `convertcom/backend` are failing on the V1 tracking build because of a lockfile-format mismatch in this submodule.

**Symptom** — backend CI build log:
```
➤ YN0028: The lockfile would have been modified by this install, which is explicitly forbidden.
__metadata:
-  version: 9
+  version: 8
```

**Root cause** — commit `a85ad99` ("chore: update yarn lock") was generated with yarn >=4.11, which writes lockfile metadata `version: 9`. But the backend's V1 tracking build runs `yarn install` in immutable mode under yarn 4.10.3 (per `public/js/tracking/package.json`'s `packageManager` field), which writes `version: 8`. The backend Ant target `build_tracking_dist_v1` does `git submodule update --remote javascript-sdk`, so it always pulls `main-convert` HEAD regardless of the pinned gitlink — meaning this lockfile breaks every backend staging deploy until fixed here.

## Changes

- `package.json`: add `"packageManager": "yarn@4.10.3+sha512..."` matching the backend tracking workspace. Locks the toolchain so future installs by any contributor don't silently drift the lockfile version.
- `yarn.lock`: regenerated with yarn 4.10.3 (the only diff vs. previous HEAD is `__metadata.version: 9` → `8`).

## Test plan

- [x] Verified `yarn install --immutable` (what CI runs) completes with warnings only — no YN0028
- [ ] Re-run backend staging deploy after merge to confirm `build_tracking_dist_v1` passes