### PR TITLE
fix(context): forward all BucketingAttributes to ExperienceManager

### DIFF
--- a/packages/js-sdk/src/context.ts
+++ b/packages/js-sdk/src/context.ts
@@ -136,9 +136,8 @@ export class Context implements ContextInterface {
       this._visitorId,
       experienceKey,
       {
+        ...attributes,
         visitorProperties, // represents audiences
-        locationProperties: attributes?.locationProperties, // represents site_area/locations
-        updateVisitorProperties: attributes?.updateVisitorProperties,
         environment: attributes?.environment || this._environment
       }
     );
@@ -190,9 +189,8 @@ export class Context implements ContextInterface {
     const bucketedVariations = this._experienceManager.selectVariations(
       this._visitorId,
       {
+        ...attributes,
         visitorProperties, // represents audiences
-        locationProperties: attributes?.locationProperties, // represents site_area/locations
-        updateVisitorProperties: attributes?.updateVisitorProperties,
         environment: attributes?.environment || this._environment
       }
     );

--- a/packages/js-sdk/tests/context.tests.ts
+++ b/packages/js-sdk/tests/context.tests.ts
@@ -179,6 +179,78 @@ describe('Context tests', function () {
         done
       );
     });
+    it('Should forward BucketingAttributes (enableTracking, forceVariationId, ignoreLocationProperties) through runExperience', function () {
+      const experienceKey = 'test-experience-ab-fullstack-2';
+      const originalSelectVariation =
+        experienceManager.selectVariation.bind(experienceManager);
+      let capturedAttributes;
+      experienceManager.selectVariation = function (
+        capturedVisitorId,
+        capturedExperienceKey,
+        attributes
+      ) {
+        capturedAttributes = attributes;
+        return originalSelectVariation(
+          capturedVisitorId,
+          capturedExperienceKey,
+          attributes
+        );
+      };
+      try {
+        context.runExperience(experienceKey, {
+          locationProperties: {url: 'https://convert.com/'},
+          visitorProperties: {varName3: 'something'},
+          enableTracking: false,
+          forceVariationId: '100299461',
+          ignoreLocationProperties: true,
+          updateVisitorProperties: true
+        });
+        expect(capturedAttributes).to.include({
+          enableTracking: false,
+          forceVariationId: '100299461',
+          ignoreLocationProperties: true,
+          updateVisitorProperties: true
+        });
+        expect(capturedAttributes.locationProperties).to.deep.equal({
+          url: 'https://convert.com/'
+        });
+      } finally {
+        experienceManager.selectVariation = originalSelectVariation;
+      }
+    });
+    it('Should forward BucketingAttributes (enableTracking, forceVariationId, ignoreLocationProperties) through runExperiences', function () {
+      const originalSelectVariations =
+        experienceManager.selectVariations.bind(experienceManager);
+      let capturedAttributes;
+      experienceManager.selectVariations = function (
+        capturedVisitorId,
+        attributes
+      ) {
+        capturedAttributes = attributes;
+        return originalSelectVariations(capturedVisitorId, attributes);
+      };
+      try {
+        context.runExperiences({
+          locationProperties: {url: 'https://convert.com/'},
+          visitorProperties: {varName3: 'something'},
+          enableTracking: false,
+          forceVariationId: '100299461',
+          ignoreLocationProperties: true,
+          updateVisitorProperties: true
+        });
+        expect(capturedAttributes).to.include({
+          enableTracking: false,
+          forceVariationId: '100299461',
+          ignoreLocationProperties: true,
+          updateVisitorProperties: true
+        });
+        expect(capturedAttributes.locationProperties).to.deep.equal({
+          url: 'https://convert.com/'
+        });
+      } finally {
+        experienceManager.selectVariations = originalSelectVariations;
+      }
+    });
     it('Shoud successfully get a single feature and its status', function (done) {
       this.timeout(test_timeout);
       getSingleFeatureWithStatus(


### PR DESCRIPTION
## Summary

`Context.runExperience` and `Context.runExperiences` rebuilt a fresh attributes object with only four hardcoded keys (`visitorProperties`, `locationProperties`, `updateVisitorProperties`, `environment`) before forwarding to `ExperienceManager.selectVariation` / `selectVariations`. Every other `BucketingAttributes` field — `enableTracking`, `forceVariationId`, `ignoreLocationProperties`, `typeCasting`, `experienceKeys` — was silently dropped.

The most user-visible consequence: a caller invoking `context.runExperience(key, { enableTracking: false })` still fires the bucketing track event, because by the time the call reaches `DataManager._getBucketingByField` (which destructures `enableTracking = true` as a default), the field has been discarded one layer up. Same for `forceVariationId` (the forced variation was never honored) and `ignoreLocationProperties`.

## Root cause

A whitelist-then-rebuild pattern in `Context` instead of spread-then-override. Two transforms must happen at the Context layer:
1. `visitorProperties` must be merged with stored visitor props via `getVisitorProperties()`.
2. `environment` must default to `this._environment` when the caller omits it.

Everything else can pass through unmodified; downstream destructures by name and ignores unknown keys.

## Fix

```ts
// before
{
  visitorProperties,
  locationProperties: attributes?.locationProperties,
  updateVisitorProperties: attributes?.updateVisitorProperties,
  environment: attributes?.environment || this._environment
}

// after
{
  ...attributes,
  visitorProperties,
  environment: attributes?.environment || this._environment
}
```

Applied identically to `runExperience` (line 135) and `runExperiences` (line 190).

`{...undefined}` evaluates to `{}` in JS, so the optional-attributes case is safe.

## Tests

Added two cases in `packages/js-sdk/tests/context.tests.ts`:
- `Should forward BucketingAttributes (enableTracking, forceVariationId, ignoreLocationProperties) through runExperience`
- `Should forward BucketingAttributes (enableTracking, forceVariationId, ignoreLocationProperties) through runExperiences`

Both monkey-patch `experienceManager.selectVariation` / `selectVariations` to capture the attributes argument, then assert the previously-dropped fields are forwarded. Use `enableTracking: false` to suppress the tracking request so the tests stay deterministic.

## Test plan

- [x] `yarn test:mocha` from `packages/js-sdk/` — 143 passing, 0 failing
- [x] `yarn lint` in `packages/js-sdk/` — clean
- [x] Existing `Shoud successfully get variation from specific experience` and `Shoud successfully get variations across all experiences` still pass (no regression in the standard path)

## Notes

- Fix is API-surface-neutral. Callers that were never passing the dropped fields see no change. Callers that were passing them and silently getting the default behavior will now get the documented behavior — this is what they expected from the public `BucketingAttributes` type all along.
- No changes to `BucketingAttributes` typing, `DataManager`, `ExperienceManager`, or any downstream layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)