### PR TITLE
feat(utils): always announce as Convert SDK via ConvertAgent User-Agent

### DIFF
--- a/packages/utils/src/http-client.ts
+++ b/packages/utils/src/http-client.ts
@@ -204,6 +204,16 @@ export const HttpClient = {
           keepalive: true // to allow the request to complete even if the page unloads
         };
         if (config?.headers) options.headers = config.headers;
+        // Always announce as Convert SDK traffic on server-side so the
+        // metrics-endpoint bot filter recognises us via its
+        // `isConvertAgentUA` bypass. Skip in browser — browsers strip
+        // User-Agent per the W3C forbidden-header list, and a browser's
+        // natural UA does not trigger isbot.
+        if (runtimeResult.runtime !== 'browser') {
+          if (!options.headers) options.headers = {};
+          (options.headers as Record<string, string>)['User-Agent'] =
+            'ConvertAgent/1.0';
+        }
         if (config?.data && supportsRequestBody(method)) {
           options.body = JSON.stringify(config.data);
         }
@@ -317,8 +327,11 @@ export const HttpClient = {
             ? JSON.stringify(config.data)
             : null;
         if (config?.headers) options.headers = config.headers;
+        // See note in the fetch branch above. old-nodejs is always
+        // server-side, so the UA announcement always applies.
+        if (!options.headers) options.headers = {};
+        options.headers['User-Agent'] = 'ConvertAgent/1.0';
         if (postData) {
-          if (!options.headers) options.headers = {};
           options.headers['Content-Length'] = Buffer.byteLength(postData);
         }
         const req = client.request(options, (res) => {

--- a/packages/utils/src/http-client.ts
+++ b/packages/utils/src/http-client.ts
@@ -9,6 +9,12 @@ import {ERROR_MESSAGES, MESSAGES} from '@convertcom/js-sdk-enums';
 import type {RequestOptions} from 'https';
 import {objectNotEmpty} from './object-utils';
 
+/**
+ * Server-side User-Agent advertised by the SDK so the metrics-endpoint
+ * bot filter recognises Convert traffic via its `isConvertAgentUA` bypass.
+ */
+const CONVERT_AGENT_USER_AGENT = 'ConvertAgent/1.0';
+
 export type HttpMethod =
   | 'GET'
   | 'DELETE'
@@ -212,7 +218,7 @@ export const HttpClient = {
         if (runtimeResult.runtime !== 'browser') {
           if (!options.headers) options.headers = {};
           (options.headers as Record<string, string>)['User-Agent'] =
-            'ConvertAgent/1.0';
+            CONVERT_AGENT_USER_AGENT;
         }
         if (config?.data && supportsRequestBody(method)) {
           options.body = JSON.stringify(config.data);
@@ -330,7 +336,7 @@ export const HttpClient = {
         // See note in the fetch branch above. old-nodejs is always
         // server-side, so the UA announcement always applies.
         if (!options.headers) options.headers = {};
-        options.headers['User-Agent'] = 'ConvertAgent/1.0';
+        options.headers['User-Agent'] = CONVERT_AGENT_USER_AGENT;
         if (postData) {
           options.headers['Content-Length'] = Buffer.byteLength(postData);
         }


### PR DESCRIPTION
## Summary

- Force `User-Agent: ConvertAgent/1.0` on every outbound HTTP request from `HttpClient` when running server-side.
- Browser path stays untouched (browsers strip User-Agent per the W3C forbidden-header list, and the browser's natural UA does not trigger isbot anyway).
- Two branches updated: `fetch` (gated on `runtimeResult.runtime !== 'browser'`) and `old-nodejs` (unconditional, always server-side).

## Why now

The May 19 metrics-endpoint isbot regression exposed that `ApiManager`'s `_trackingSource` (`network.source` on the wire) is customer-configurable. Combined with the CI source-stamping pattern (rollup writes `js<version>` at build time), the wire-side source value is in two ways out of our control — customer config and CI environment. Either could silently break the metrics-endpoint's source-field bypass and re-create the May 19 outage shape.

Baking the UA at the lowest transport layer (`HttpClient.request()` in `packages/utils/src/http-client.ts`) makes the announcement an SDK invariant — not config-driven, not env-driven, not customer-overridable. Metrics-endpoint code stays untouched (the `isConvertAgentUA` bypass has been in place since 2026-05-20 17:06 UTC).

## What stays in place

The source-field bypass at the metrics endpoint remains as legacy fallback for already-deployed SDK versions. Customers on older SDKs continue to work via the `/^js\d+\.\d+\.\d+/` regex path.

## Test plan

- [ ] CI green on existing jest / tsc / ESLint pipelines
- [ ] Targeted unit test in `packages/utils` to verify `User-Agent: ConvertAgent/1.0` is present on `HttpClient.request()` outputs when `determineRuntime()` returns `server-with-fetch` or `old-nodejs`, and absent (or rather, left to whatever caller set) when `browser`
- [ ] Smoke against staging metrics endpoint from a Node runtime to confirm `botCheckSkipped` events fire with the ConvertAgent UA bypass path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215078751388979