### PR TITLE
fix(js-sdk): document ConvertAgent UA invariant (trigger js-sdk release)

### DIFF
--- a/packages/js-sdk/src/core.ts
+++ b/packages/js-sdk/src/core.ts
@@ -3,6 +3,11 @@
  * Version 1.0.0
  * Copyright(c) 2020 Convert Insights, Inc
  * License Apache-2.0
+ *
+ * Server-side HTTP requests issued through this SDK announce themselves as
+ * `User-Agent: ConvertAgent/1.0` (see packages/utils/src/http-client.ts). This
+ * is an SDK invariant relied on by the metrics endpoint's isbot bypass and is
+ * not customer- or env-configurable.
  */
 import {ApiManagerInterface} from '@convertcom/js-sdk-api';
 import {ContextInterface} from './interfaces/context';


### PR DESCRIPTION
## Summary

- Documents the `User-Agent: ConvertAgent/1.0` invariant from #387 at the js-sdk package entry point (`packages/js-sdk/src/core.ts`).
- Carries a `fix(js-sdk):` conventional commit so release-please attributes a patch bump to `js-sdk` (4.4.1 → 4.4.2) alongside the already-queued `utils` bump.

## Why

PR #387 only touched `packages/utils/src/http-client.ts` with `feat(utils):`, so release-please only bumped `utils` (2.2.0 → 2.3.0). The behavior change ships through `js-sdk` as well, but release-please scopes bumps strictly by file path + commit scope — so without a js-sdk-side commit, consumers pinning `@convertcom/js-sdk` see no version delta despite the wire-level change.

This PR adds a documentation-only note at the SDK entry point so the contract is visible to integrators and release-please attributes the change to `js-sdk`. No behavioral change.

## Follow-up

After this merges into `main-convert`, a separate `main-convert` → `main` PR will let release-please pick up the new commit and include the `js-sdk` patch bump in its release PR.

## Test plan

- [ ] CI green (jest / tsc / ESLint / SonarCloud)
- [ ] After merge to `main`, release-please PR includes a `js-sdk` 4.4.1 → 4.4.2 entry

Refs: #387, #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)