### PR TITLE
fix(ci): bootstrap yarn via corepack to match packageManager pin

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,25 +14,26 @@ jobs:
         node: [22]
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
         with:
-          # The Node.js version to configure
           node-version: ${{ matrix.node }}
 
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - name: Setup Yarn
+        run: |
+          corepack enable
+          corepack prepare yarn@4.10.3 --activate
 
       - name: Install needed libraries and packages
         run: |
-          wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add - 
+          wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
           sudo sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
           sudo apt-get update
           sudo apt-get install -y google-chrome-stable
 
       - name: Installing npm packages
-        run: |
-          yarn set version berry
-          yarn
+        run: yarn
 
       - name: Generating coverage and docs
         run: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,7 +33,7 @@ jobs:
           sudo apt-get install -y google-chrome-stable
 
       - name: Installing npm packages
-        run: yarn
+        run: yarn install --immutable
 
       - name: Generating coverage and docs
         run: |

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -19,9 +19,11 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Resolve tag
         run: echo "RELEASE_TAG=${{ github.event.release.tag_name || inputs.tag }}" >> $GITHUB_ENV
-      - run: |
-          yarn set version berry
-          yarn
+      - name: Setup Yarn
+        run: |
+          corepack enable
+          corepack prepare yarn@4.10.3 --activate
+      - run: yarn
       - if: ${{ startsWith(env.RELEASE_TAG, 'js-sdk-enums-v') }}
         run: |
           yarn enums:build

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -23,7 +23,8 @@ jobs:
         run: |
           corepack enable
           corepack prepare yarn@4.10.3 --activate
-      - run: yarn
+      - name: Install deps
+        run: yarn install --immutable
       - if: ${{ startsWith(env.RELEASE_TAG, 'js-sdk-enums-v') }}
         run: |
           yarn enums:build

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,10 +34,12 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
-      - name: Install deps
+      - name: Setup Yarn
         run: |
-          yarn set version berry
-          yarn
+          corepack enable
+          corepack prepare yarn@4.10.3 --activate
+      - name: Install deps
+        run: yarn
       - name: Build & publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,7 +39,7 @@ jobs:
           corepack enable
           corepack prepare yarn@4.10.3 --activate
       - name: Install deps
-        run: yarn
+        run: yarn install --immutable
       - name: Build & publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Three workflows still bootstrap yarn via the v1-era `yarn set version berry` trick. Since the `packageManager: yarn@4.10.3` pin landed in 38cc9a9, that bootstrap now fails on push to `main` — the runner's pre-installed Yarn 1.22.22 refuses to operate against a project with a `packageManager` field and demands corepack.
- Concrete fallout from the PR #390 merge (today, 15:01 UTC):
  - `pages.yml` failed at "Installing npm packages" → run `26406885986`.
  - `release-please.yml` publish jobs failed at "Install deps" for `packages/types`, `packages/utils`, `packages/js-sdk` → run `26406886058`. The release **tags** got created (v3.13.0 / v2.4.0 / v4.4.2 exist on GitHub), but **none were published to npm**.
  - `publish-package.yml` has the same defect — latent until the next manual `workflow_dispatch`.
- Fix mirrors the working pattern already in `qa.yml`: `corepack enable` + `corepack prepare yarn@4.10.3 --activate` (matching the explicit pin), then plain `yarn` install. The `yarn set version berry` line is removed from all three workflows.
- Also bumps `pages.yml`'s `actions/setup-node@v1` and `actions/checkout@v2` to `@v4` (both prior majors are EOL).

## Test plan
- [ ] CI: `Running QA automated checks` passes on this PR (it doesn't use any of the changed files, but should remain green).
- [ ] After merge, the auto-triggered `Updating Github pages` run on `main` succeeds.
- [ ] After merge, manually publish the 3 pending releases:
  - `gh workflow run publish-package.yml -f tag=js-sdk-types-v3.13.0`
  - `gh workflow run publish-package.yml -f tag=js-sdk-utils-v2.4.0`
  - `gh workflow run publish-package.yml -f tag=js-sdk-v4.4.2`
- [ ] Confirm all three appear on npm with the new versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)