### PR TITLE
chore(ci): remove redundant publish job from release-please.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,53 +11,9 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    outputs:
-      releases_created: ${{ steps.release.outputs.releases_created }}
-      paths_released: ${{ steps.release.outputs.paths_released }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-
-  publish:
-    needs: release
-    if: ${{ needs.release.outputs.releases_created && needs.release.outputs.paths_released != '[]' }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rel: ${{ fromJson(needs.release.outputs.paths_released) }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org
-      - name: Setup Yarn
-        run: |
-          corepack enable
-          corepack prepare yarn@4.10.3 --activate
-      - name: Install deps
-        run: yarn install --immutable
-      - name: Build & publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          REL_PATH: ${{ matrix.rel }}
-        run: |
-          case "$REL_PATH" in
-            packages/enums)       yarn enums:build       && (cd packages/enums       && npm publish --access public) ;;
-            packages/types)       yarn types:build       && (cd packages/types       && npm publish --access public) ;;
-            packages/utils)       yarn utils:build       && (cd packages/utils       && npm publish --access public) ;;
-            packages/event)       yarn event:build       && (cd packages/event       && npm publish --access public) ;;
-            packages/bucketing)   yarn bucketing:build   && (cd packages/bucketing   && npm publish --access public) ;;
-            packages/logger)      yarn logger:build      && (cd packages/logger      && npm publish --access public) ;;
-            packages/rules)       yarn rules:build       && (cd packages/rules       && npm publish --access public) ;;
-            packages/segments)    yarn segments:build    && (cd packages/segments    && npm publish --access public) ;;
-            packages/api)         yarn api:build         && (cd packages/api         && npm publish --access public) ;;
-            packages/data)        yarn data:build        && (cd packages/data        && npm publish --access public) ;;
-            packages/experience)  yarn experience:build  && (cd packages/experience  && npm publish --access public) ;;
-            packages/js-sdk)      yarn sdk:build         && (cd packages/js-sdk      && npm publish --access public) ;;
-            packages/cloudflare)  yarn cloudflare:build  && (cd packages/cloudflare  && npm publish --access public) ;;
-            *) echo "Unknown path: $REL_PATH" && exit 1 ;;
-          esac


### PR DESCRIPTION
## Summary

- Removes the `publish` matrix job from `.github/workflows/release-please.yml`, which duplicated `publish-package.yml` and was the last consumer of the `NPM_TOKEN` secret.
- `release-please.yml` now does only what its name suggests: manages versions, changelogs, tags, and GitHub Releases. The actual npm publish stays in `publish-package.yml`, which since #395 publishes via npm Trusted Publishers (OIDC).
- Also drops the `outputs` block on the `release` job (`releases_created` / `paths_released`) — nothing consumes it anymore.

## Why this is safe

Future merges to `main` will behave exactly as before:

1. Push to `main` → release-please opens/updates the Release PR.
2. Merge the Release PR → release-please cuts per-package tags (e.g. `js-sdk-v4.4.3`) and creates a GitHub Release for each.
3. Each `release: published` event triggers `publish-package.yml` → OIDC publish to npm.

The only thing that goes away is a second, racing publish path that authenticated with `NPM_TOKEN` and could only publish 2 of the 13 packages (the same gap that motivated #395).

## Follow-up (not in this PR)

- Once this is merged and a Release PR cycle has run successfully end-to-end, the `NPM_TOKEN` repo secret can be deleted from repo settings.

## Test plan

- [ ] On merge: confirm no workflow regressions on the next push to `main` (release-please should still update its Release PR).
- [ ] On the next merged Release PR: confirm tags + GitHub Releases are created, and `publish-package.yml` runs once per release and publishes successfully via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)