### PR TITLE
fix(ci): build before test and install Playwright browsers in pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,11 +35,16 @@ jobs:
       - name: Installing npm packages
         run: yarn install --immutable
 
+      - name: Install Playwright browsers
+        run: |
+          cd packages/js-sdk
+          yarn playwright install --with-deps chromium
+
       - name: Generating coverage and docs
         run: |
           cd packages/js-sdk
-          yarn test
           yarn build
+          yarn test
 
       - name: Checkout gh-pages
         uses: actions/checkout@v3


### PR DESCRIPTION
## Summary

The `Updating Github pages` workflow has been failing on every push to `main` since the Karma→Playwright migration (commit `be7e235`). Two issues, both fixed here:

### 1. Build runs after test, but the integration test requires the build output

`packages/js-sdk/tests/integration/full-chain.spec.ts:5`:
```js
const SDK = require('../../lib/index');
```

`lib/` is the rollup output produced by `yarn build`. The current order in `Generating coverage and docs` was `yarn test` then `yarn build`, so Playwright's test-file discovery crashed:

```
Error: Cannot find module '../../lib/index'
Require stack:
- .../packages/js-sdk/tests/integration/full-chain.spec.ts
- .../node_modules/playwright/lib/transform/transform.js
```

The crash happens *before* any browser even launches.

### 2. Playwright's bundled chromium was never installed

The workflow installs system `google-chrome-stable` (Karma-era leftover), but Playwright uses its own bundled chromium binary, not the system Chrome. Without `playwright install`, the browser tests would fail at browser-launch time even after fixing (1).

### Why this didn't bite us in PRs

`qa.yml` already had both pieces in place: it runs `yarn build` before `yarn test:mocha`/`yarn test:browser`, and it runs `yarn playwright install --with-deps chromium`. So PR-time checks pass while `pages.yml` has been red on every merge.

This change brings `pages.yml` into alignment.

## Note

The system `google-chrome-stable` install block is left untouched — it's now redundant with `--with-deps` doing the same thing via apt-get, but removing it is scope-creep cleanup that should be a separate PR.

## Test plan
- [ ] After merge, the merge commit's auto-triggered `Updating Github pages` run on `main` completes successfully.
- [ ] Verify the gh-pages branch is updated with fresh docs/coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)