### PR TITLE
fix(utils): classify browser Web Workers as browser runtime in HttpClient

### DIFF
--- a/packages/utils/src/http-client.ts
+++ b/packages/utils/src/http-client.ts
@@ -146,7 +146,7 @@ const determineRuntime = (): RuntimeResult => {
   // endpoint rejected, breaking every signals worker upload).
   if (
     typeof self !== 'undefined' &&
-    typeof (self as {importScripts?: unknown}).importScripts === 'function'
+    typeof (self as {importScripts?: unknown})?.importScripts === 'function'
   ) {
     return {runtime: 'browser'};
   }

--- a/packages/utils/src/http-client.ts
+++ b/packages/utils/src/http-client.ts
@@ -137,6 +137,20 @@ const determineRuntime = (): RuntimeResult => {
     return {runtime: 'browser'};
   }
 
+  // Browser Web Workers have no `window` but are still browser runtimes.
+  // `importScripts` exists only in browser worker scopes — server runtimes
+  // (Node.js) and edge runtimes (e.g. Cloudflare Workers) do not expose it.
+  // Without this check a Web Worker falls through to 'server-with-fetch' and
+  // server-side-only behavior leaks into real browsers (the ConvertAgent
+  // User-Agent announcement below forced a CORS preflight the signals
+  // endpoint rejected, breaking every signals worker upload).
+  if (
+    typeof self !== 'undefined' &&
+    typeof (self as {importScripts?: unknown}).importScripts === 'function'
+  ) {
+    return {runtime: 'browser'};
+  }
+
   // if window is not available, but fetch is, then we're on a server that has the fetch API available
   if (typeof fetch === 'function') {
     return {runtime: 'server-with-fetch'};


### PR DESCRIPTION
## Associated Ticket
https://app.asana.com/1/145550540855/project/1204450923340067/task/1215427653611922

## What does this PR do?
Description:
* Root cause of the Jun 3rd AWS WAF cost anomaly: `determineRuntime()` in `packages/utils/src/http-client.ts` equated "no `window`" with server-side, so the signals Web Worker classified as `server-with-fetch` and the ConvertAgent `User-Agent` announcement (server-side only by design) ran inside real browsers. The resulting custom request header forces a CORS preflight the signals endpoint rejects → every signals worker upload fails → the worker retry loop turns each sampled tab into ~2 preflights/second (~190M extra requests/day on the signals web ACL, worker-batched Signals collection dead since Jun 3rd).
* Browser worker scopes are now detected via `importScripts`, which only exists in browser workers — Node.js and edge runtimes (Cloudflare Workers) don't expose it, so server-side and edge traffic keeps announcing `ConvertAgent/1.0` for the metrics-endpoint `isConvertAgentUA` bot-filter bypass exactly as intended.
* Includes an empty `fix(js-sdk):` commit so `@convertcom/js-sdk` also receives a release carrying the patched utils dependency.

Verified: `HttpClient.request` against a local capture server announces `ConvertAgent/1.0` in a plain Node runtime and stops injecting the header when a worker scope (`self.importScripts`) is present. `@convertcom/js-sdk-utils` builds clean and its suite passes 120/120.

Related: convertcom/backend#6694 (tracking build: stop property-mangling the header name + CORS-faithful signals tests), convertcom/backend#6695 (signals endpoint: authorize the headers, stops the WAF bleed for already-deployed clients).

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Hot Fix
- [ ] Optimization
- [ ] Documentation Update

## Added tests?

- [ ] Yes
- [x] No, because they aren't needed
- [ ] No, because I need help

(`determineRuntime` is module-private; the integration-level regression test lives in convertcom/backend#6694 — the signals browser suite now exercises real cross-origin CORS and asserts upload delivery, which fails if this class of bug ships again.)

## QA Instructions, Screenshots, Recordings
* `yarn workspace @convertcom/js-sdk-utils build && yarn workspace @convertcom/js-sdk-utils test:mocha`
* Behavioral check: import `HttpClient` from the built lib in Node against a local HTTP server → request carries `User-Agent: ConvertAgent/1.0`; set `globalThis.self = {importScripts(){}}` and repeat → header no longer injected
* After the backend tracking submodule picks this up: `cd public/js/tracking && yarn build:testing && yarn test:signals --reporter=list` stays 9/9

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215427653611952