### PR TITLE
Sync main into main-convert

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,25 +14,26 @@ jobs:
         node: [22]
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
         with:
-          # The Node.js version to configure
           node-version: ${{ matrix.node }}
 
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - name: Setup Yarn
+        run: |
+          corepack enable
+          corepack prepare yarn@4.10.3 --activate
 
       - name: Install needed libraries and packages
         run: |
-          wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add - 
+          wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
           sudo sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
           sudo apt-get update
           sudo apt-get install -y google-chrome-stable
 
       - name: Installing npm packages
-        run: |
-          yarn set version berry
-          yarn
+        run: yarn
 
       - name: Generating coverage and docs
         run: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,11 +35,16 @@ jobs:
       - name: Installing npm packages
         run: yarn install --immutable
 
+      - name: Install Playwright browsers
+        run: |
+          cd packages/js-sdk
+          yarn playwright install --with-deps chromium
+
       - name: Generating coverage and docs
         run: |
           cd packages/js-sdk
-          yarn test
           yarn build
+          yarn test
 
       - name: Checkout gh-pages
         uses: actions/checkout@v3

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,7 +33,7 @@ jobs:
           sudo apt-get install -y google-chrome-stable
 
       - name: Installing npm packages
-        run: yarn
+        run: yarn install --immutable
 
       - name: Generating coverage and docs
         run: |

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -19,9 +19,11 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Resolve tag
         run: echo "RELEASE_TAG=${{ github.event.release.tag_name || inputs.tag }}" >> $GITHUB_ENV
-      - run: |
-          yarn set version berry
-          yarn
+      - name: Setup Yarn
+        run: |
+          corepack enable
+          corepack prepare yarn@4.10.3 --activate
+      - run: yarn
       - if: ${{ startsWith(env.RELEASE_TAG, 'js-sdk-enums-v') }}
         run: |
           yarn enums:build

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -10,13 +10,20 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v4
         with:
           node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
+      - name: Ensure npm >= 11.5.1 (required for Trusted Publisher OIDC)
+        run: npm install -g npm@latest
       - name: Resolve tag
         run: echo "RELEASE_TAG=${{ github.event.release.tag_name || inputs.tag }}" >> $GITHUB_ENV
       - name: Setup Yarn
@@ -29,77 +36,51 @@ jobs:
         run: |
           yarn enums:build
           (cd packages/enums && npm publish --access public)
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - if: ${{ startsWith(env.RELEASE_TAG, 'js-sdk-types-v') }}
         run: |
           yarn types:build
           (cd packages/types && npm publish --access public)
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - if: ${{ startsWith(env.RELEASE_TAG, 'js-sdk-utils-v') }}
         run: |
           yarn utils:build
           (cd packages/utils && npm publish --access public)
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - if: ${{ startsWith(env.RELEASE_TAG, 'js-sdk-event-v') }}
         run: |
           yarn event:build
           (cd packages/event && npm publish --access public)
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - if: ${{ startsWith(env.RELEASE_TAG, 'js-sdk-bucketing-v') }}
         run: |
           yarn bucketing:build
           (cd packages/bucketing && npm publish --access public)
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - if: ${{ startsWith(env.RELEASE_TAG, 'js-sdk-logger-v') }}
         run: |
           yarn logger:build
           (cd packages/logger && npm publish --access public)
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - if: ${{ startsWith(env.RELEASE_TAG, 'js-sdk-rules-v') }}
         run: |
           yarn rules:build
           (cd packages/rules && npm publish --access public)
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - if: ${{ startsWith(env.RELEASE_TAG, 'js-sdk-segments-v') }}
         run: |
           yarn segments:build
           (cd packages/segments && npm publish --access public)
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - if: ${{ startsWith(env.RELEASE_TAG, 'js-sdk-api-v') }}
         run: |
           yarn api:build
           (cd packages/api && npm publish --access public)
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - if: ${{ startsWith(env.RELEASE_TAG, 'js-sdk-data-v') }}
         run: |
           yarn data:build
           (cd packages/data && npm publish --access public)
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - if: ${{ startsWith(env.RELEASE_TAG, 'js-sdk-experience-v') }}
         run: |
           yarn experience:build
           (cd packages/experience && npm publish --access public)
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - if: ${{ startsWith(env.RELEASE_TAG, 'js-sdk-cloudflare-v') }}
         run: |
           yarn cloudflare:build
           (cd packages/cloudflare && npm publish --access public)
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - if: ${{ startsWith(env.RELEASE_TAG, 'js-sdk-v') }}
         run: |
           yarn sdk:build
           (cd packages/js-sdk && npm publish --access public)
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -23,7 +23,8 @@ jobs:
         run: |
           corepack enable
           corepack prepare yarn@4.10.3 --activate
-      - run: yarn
+      - name: Install deps
+        run: yarn install --immutable
       - if: ${{ startsWith(env.RELEASE_TAG, 'js-sdk-enums-v') }}
         run: |
           yarn enums:build

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,10 +34,12 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
-      - name: Install deps
+      - name: Setup Yarn
         run: |
-          yarn set version berry
-          yarn
+          corepack enable
+          corepack prepare yarn@4.10.3 --activate
+      - name: Install deps
+        run: yarn
       - name: Build & publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,7 +39,7 @@ jobs:
           corepack enable
           corepack prepare yarn@4.10.3 --activate
       - name: Install deps
-        run: yarn
+        run: yarn install --immutable
       - name: Build & publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,53 +11,9 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    outputs:
-      releases_created: ${{ steps.release.outputs.releases_created }}
-      paths_released: ${{ steps.release.outputs.paths_released }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-
-  publish:
-    needs: release
-    if: ${{ needs.release.outputs.releases_created && needs.release.outputs.paths_released != '[]' }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rel: ${{ fromJson(needs.release.outputs.paths_released) }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org
-      - name: Setup Yarn
-        run: |
-          corepack enable
-          corepack prepare yarn@4.10.3 --activate
-      - name: Install deps
-        run: yarn install --immutable
-      - name: Build & publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          REL_PATH: ${{ matrix.rel }}
-        run: |
-          case "$REL_PATH" in
-            packages/enums)       yarn enums:build       && (cd packages/enums       && npm publish --access public) ;;
-            packages/types)       yarn types:build       && (cd packages/types       && npm publish --access public) ;;
-            packages/utils)       yarn utils:build       && (cd packages/utils       && npm publish --access public) ;;
-            packages/event)       yarn event:build       && (cd packages/event       && npm publish --access public) ;;
-            packages/bucketing)   yarn bucketing:build   && (cd packages/bucketing   && npm publish --access public) ;;
-            packages/logger)      yarn logger:build      && (cd packages/logger      && npm publish --access public) ;;
-            packages/rules)       yarn rules:build       && (cd packages/rules       && npm publish --access public) ;;
-            packages/segments)    yarn segments:build    && (cd packages/segments    && npm publish --access public) ;;
-            packages/api)         yarn api:build         && (cd packages/api         && npm publish --access public) ;;
-            packages/data)        yarn data:build        && (cd packages/data        && npm publish --access public) ;;
-            packages/experience)  yarn experience:build  && (cd packages/experience  && npm publish --access public) ;;
-            packages/js-sdk)      yarn sdk:build         && (cd packages/js-sdk      && npm publish --access public) ;;
-            packages/cloudflare)  yarn cloudflare:build  && (cd packages/cloudflare  && npm publish --access public) ;;
-            *) echo "Unknown path: $REL_PATH" && exit 1 ;;
-          esac

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,8 +1,8 @@
 {
-  "packages/js-sdk": "4.4.1",
+  "packages/js-sdk": "4.4.2",
   "packages/enums": "2.3.0",
-  "packages/types": "3.12.0",
-  "packages/utils": "2.3.0",
+  "packages/types": "3.13.0",
+  "packages/utils": "2.4.0",
   "packages/event": "2.1.3",
   "packages/bucketing": "3.1.2",
   "packages/logger": "2.1.2",

--- a/packages/js-sdk/CHANGELOG.md
+++ b/packages/js-sdk/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [4.4.2](https://github.com/convertcom/javascript-sdk/compare/js-sdk-v4.4.1...js-sdk-v4.4.2) (2026-05-25)
+
+
+### Bug Fixes
+
+* **js-sdk:** document ConvertAgent UA invariant (trigger js-sdk release) ([c4d1224](https://github.com/convertcom/javascript-sdk/commit/c4d12247a02da4572dc54fe55586c9752d8ff236))
+* **js-sdk:** document ConvertAgent User-Agent invariant on server-side HTTP ([7244fc8](https://github.com/convertcom/javascript-sdk/commit/7244fc8e8e87fecc7f9ed236319dc9e5a5184a0a)), closes [#387](https://github.com/convertcom/javascript-sdk/issues/387)
+
 ## [4.4.1](https://github.com/convertcom/javascript-sdk/compare/js-sdk-v4.4.0...js-sdk-v4.4.1) (2026-05-21)
 
 

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -85,7 +85,7 @@
     "watchify": "^4.0.0",
     "webpack": "^5.102.1"
   },
-  "version": "4.4.1",
+  "version": "4.4.2",
   "peerDependencies": {
     "@convertcom/js-sdk-api": ">=2.1.4",
     "@convertcom/js-sdk-bucketing": ">=3.1.2",

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.13.0](https://github.com/convertcom/javascript-sdk/compare/js-sdk-types-v3.12.0...js-sdk-types-v3.13.0) (2026-05-25)
+
+
+### Features
+
+* automated TS Serving API update ([94d3246](https://github.com/convertcom/javascript-sdk/commit/94d3246b35424b20a8f80b8c55d14366c49c084b))
+
 ## [3.12.0](https://github.com/convertcom/javascript-sdk/compare/js-sdk-types-v3.11.0...js-sdk-types-v3.12.0) (2026-05-21)
 
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -49,7 +49,7 @@
     "typescript-eslint": "^8.46.4",
     "webpack": "^5.102.1"
   },
-  "version": "3.12.0",
+  "version": "3.13.0",
   "peerDependencies": {
     "@convertcom/js-sdk-enums": ">=2.3.0"
   }

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.4.0](https://github.com/convertcom/javascript-sdk/compare/js-sdk-utils-v2.3.0...js-sdk-utils-v2.4.0) (2026-05-25)
+
+
+### Features
+
+* **utils:** always announce as Convert SDK via ConvertAgent User-Agent ([0c68a45](https://github.com/convertcom/javascript-sdk/commit/0c68a45bba928c206474a0c569eb654c9f5a53ee))
+* **utils:** always announce as Convert SDK via ConvertAgent User-Agent ([fa7e6f9](https://github.com/convertcom/javascript-sdk/commit/fa7e6f9726fa612fe1cca56c60dcc6e38e54d0a5))
+
 ## [2.3.0](https://github.com/convertcom/javascript-sdk/compare/js-sdk-utils-v2.2.3...js-sdk-utils-v2.3.0) (2026-05-21)
 
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -70,7 +70,7 @@
     "typescript-eslint": "^8.46.4",
     "webpack": "^5.102.1"
   },
-  "version": "2.3.0",
+  "version": "2.4.0",
   "peerDependencies": {
     "@convertcom/js-sdk-enums": ">=2.3.0"
   }


### PR DESCRIPTION
Brings `main-convert` up to date with `main` so PR #402 is no longer behind.

`main` moved ahead of `main-convert` via PRs that landed directly on `main` after the last sync (#393): #394, #395, #396, #397 (CI fixes) and the release-please release commit (#390). This merges those back, same pattern as #393.

🤖 Generated with [Claude Code](https://claude.com/claude-code)