### PR TITLE
fix(ci): auto-dispatch npm publish when release-please creates releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   release:
@@ -17,3 +18,13 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+      - name: Dispatch npm publish for released packages
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_OUTPUTS: ${{ toJSON(steps.release.outputs) }}
+        run: |
+          for tag in $(echo "$RELEASE_OUTPUTS" | jq -r 'to_entries[] | select(.key | endswith("--tag_name")) | .value'); do
+            echo "Dispatching publish-package.yml for $tag"
+            gh workflow run publish-package.yml --repo "$GITHUB_REPOSITORY" -f tag="$tag"
+          done


### PR DESCRIPTION
## Problem

Merging a release-please PR (e.g. #404) creates the GitHub releases + tags, but **nothing is published to npm**. Every publish has had to be dispatched manually via `publish-package.yml`'s `workflow_dispatch`.

## Root cause

The releases are created by `release-please-action` using the default `GITHUB_TOKEN`. Per [GitHub's docs](https://docs.github.com/en/actions/concepts/security/github_token), events triggered by `GITHUB_TOKEN` **do not create new workflow runs** — so `publish-package.yml`'s `on: release: published` trigger never fires. Its run history confirms it: only manual `workflow_dispatch` runs, ever.

## Fix

Same docs, the exception: *"`workflow_dispatch` and `repository_dispatch` events always create workflow runs."*

So the `release` job now dispatches the **existing** `publish-package.yml` (via its existing `tag` input) once per released tag, using the per-path `<path>--tag_name` outputs of release-please-action v4. `publish-package.yml` is untouched and remains the single publishing path — this just automates the exact manual dispatch flow used until now.

Requires `actions: write` permission (added) for `gh workflow run`.

## Verification plan

Next release-please merge should show one `Publish Package to npmjs` run per released tag, each `workflow_dispatch`, with matching npm versions afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)